### PR TITLE
Release/0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `image-view/` is the Rust crate root (run Cargo commands from here).
+- `image-view/src/main.rs` contains the CLI entry point and core logic.
+- `image-view/Dockerfile` and `image-view/build.sh` support Docker packaging.
+- `src/main_test.rs` holds a minimal test stub at the repo root.
+- `artifacts/` and `target/` are build output directories.
+
+## Build, Test, and Development Commands
+Run these from `image-view/` unless noted.
+- `cargo build --release`: build optimized binary.
+- `cargo run -- <args>`: run the CLI locally.
+- `cargo install --path .`: install locally from source into `~/.cargo/bin`.
+- `cargo test`: run Rust tests (only those inside the crate).
+- `./build.sh <image_name> <tag>`: build the release binary, build a Docker image, run it, then clean up (requires Docker).
+
+## Coding Style & Naming Conventions
+- Rust 2021 edition; use standard Rust formatting (4-space indent, rustfmt-compatible style).
+- Naming: `snake_case` for functions/vars, `UpperCamelCase` for types, `SCREAMING_SNAKE_CASE` for constants.
+- Keep modules small and focused; prefer explicit error messages for CLI output.
+
+## Testing Guidelines
+- Place unit tests in `image-view/src` using `#[cfg(test)]` or integration tests in `image-view/tests/`.
+- Current stub test lives in `src/main_test.rs`; move or duplicate tests into the crate so `cargo test` picks them up.
+- Name tests for behavior, e.g., `opens_image_path` or `rejects_missing_file`.
+
+## Commit & Pull Request Guidelines
+- Git history only shows an “Initial commit”; no strict convention is established yet.
+- Use concise, imperative commit subjects (e.g., "Add PNG decoding"), one topic per commit.
+- PRs should include: a short summary, how to run/verify, and sample CLI output or screenshots if behavior changes.
+
+## Configuration & Deployment Notes
+- Docker builds use `image-view/Dockerfile`; the helper script runs and removes containers/images, so don’t point it at production tags.
+- If you add config files, document defaults in `image-view/README.md`.
+
+## Script Helpers
+- `scripts/script-helpers/` is a vendored git module; do not edit files inside it.
+- Scripts in `scripts/` should use `script-helpers` for `-h/--help` output (via `helpers.sh`, `shlib_import help`, and `parse_common_args`).
+
+## CI Helpers
+- GitHub Actions workflows in `.github/workflows/` use the shared `ci-helpers` library.
+- References should track the `@production` branch unless explicitly requested otherwise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 This format is based on Keep a Changelog and follows Semantic Versioning.
 
 ## [Unreleased]
+### Changed
+- Fix gallery rendering alignment by using explicit CRLF line endings in raw mode.
+- Show full path beneath gallery images with dynamic height adjustment.
+- Improve clipboard handling across environments (X11 owner retention, WSL/macOS/Wayland/OSC 52 fallbacks).
 
 ## [0.2.0] - 2025-08-30
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image 0.25.9",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,10 +65,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "color_quant"
@@ -101,10 +136,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
 
 [[package]]
 name = "either"
@@ -123,6 +193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "exr"
 version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +211,26 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -154,6 +250,16 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -190,17 +296,33 @@ dependencies = [
  "gif",
  "jpeg-decoder",
  "num-traits",
- "png",
+ "png 0.17.16",
  "qoi",
- "tiff",
+ "tiff 0.9.1",
+]
+
+[[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.0",
+ "tiff 0.10.3",
 ]
 
 [[package]]
 name = "image-view"
 version = "0.1.0"
 dependencies = [
+ "arboard",
  "colored",
- "image",
+ "crossterm",
+ "image 0.24.9",
  "terminal_size",
 ]
 
@@ -238,6 +360,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +388,28 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -257,12 +422,127 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -279,6 +559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +575,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -317,6 +612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,8 +629,58 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -358,7 +712,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.48.0",
 ]
 
@@ -374,16 +728,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -540,6 +936,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.3",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,10 +973,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +326,7 @@ name = "image-view"
 version = "0.1.0"
 dependencies = [
  "arboard",
+ "base64",
  "colored",
  "crossterm",
  "image 0.24.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2024"
 image = "0.24"
 terminal_size = "^0.3"
 colored = "^2.0"
+crossterm = "0.27"
+arboard = "3.4"
 
 [[bin]]
 name = "image-view"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ terminal_size = "^0.3"
 colored = "^2.0"
 crossterm = "0.27"
 arboard = "3.4"
+base64 = "0.22"
 
 [[bin]]
 name = "image-view"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,20 @@ RUN apt-get update && apt-get install -y \
 # Install rustup and Rust toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+ENV CARGO_INCREMENTAL=0
+ENV CARGO_TERM_COLOR=always
+RUN rustup component add rustfmt clippy
 
 WORKDIR /usr/src/app
 COPY . .
+
+# Lint (CI parity)
+ARG RUN_LINT=1
+RUN if [ "$RUN_LINT" = "1" ]; then \
+      cargo fmt -- --check && cargo clippy -- -D warnings; \
+    else \
+      echo "Skipping lint (RUN_LINT=0)"; \
+    fi
 
 # Add Rust targets
 RUN rustup target add x86_64-pc-windows-gnu

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Render images directly in your terminal.
 
 ## Overview
 
-**image-view** is a Rust-based command-line tool that enables you to display image files (such as JPEG, PNG, etc.) right in your terminal window. It leverages terminal graphics protocols (like Sixel or Kitty graphics) to render images inline, making it useful for quick previews without leaving the command line.
+**image-view** is a Rust-based command-line tool that enables you to display image files (such as JPEG, PNG, etc.) right in your terminal window. It renders images using colored background blocks, making it useful for quick previews without leaving the command line.
 
 Key features:
-- **Terminal Image Rendering:** Supports common image formats and displays them using compatible terminal graphics protocols.
+- **Terminal Image Rendering:** Supports common image formats and displays them using colored background blocks.
 - **Cross-Platform:** Runs on Linux, macOS, and Windows (with supported terminals).
 - **Docker Support:** Includes a Dockerfile and build script for containerized usage and deployment.
 - **CI/CD Integration:** GitHub Actions workflow automates building and packaging for multiple platforms.
+- **Gallery Mode:** Browse a directory of images with left/right navigation and copy the current image path.
 
 Typical usage:
 
@@ -53,6 +54,25 @@ This installs `image-view` into `~/.cargo/bin`. Ensure it is on your `PATH`.
 
 - edit `./src/main.rs`
 - build: `cargo run ./src/test.jpeg`
+
+## Usage
+
+Render a single image:
+
+```bash
+image-view <image-path> [-w <width>] [-h <height>]
+```
+
+Gallery mode (browse a directory):
+
+```bash
+image-view -g [path]
+```
+
+Controls in gallery mode:
+- Left/Right arrows: previous/next image
+- Ctrl+C (Cmd+C on macOS): copy full path of current image (shows "Copied" under the path)
+- q: quit
 
 
 ## Project Structure

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,8 @@ source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import help logging
 parse_common_args "$@"
 
-docker build -t rust-project .
+BUILD_MACOS="${BUILD_MACOS:-0}"
+docker build --build-arg BUILD_MACOS="$BUILD_MACOS" -t rust-project .
 
 # Run the Docker container with the mounted volume
 docker run --rm -v "$(pwd)/target/release:/app/target/release" rust-project

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,8 @@ shlib_import help logging
 parse_common_args "$@"
 
 BUILD_MACOS="${BUILD_MACOS:-0}"
-docker build --build-arg BUILD_MACOS="$BUILD_MACOS" -t rust-project .
+RUN_LINT="${RUN_LINT:-1}"
+docker build --build-arg BUILD_MACOS="$BUILD_MACOS" --build-arg RUN_LINT="$RUN_LINT" -t rust-project .
 
 # Run the Docker container with the mounted volume
 docker run --rm -v "$(pwd)/target/release:/app/target/release" rust-project

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -43,16 +43,22 @@ if [ "$fix_mode" -eq 1 ]; then
     cd "$ROOT_DIR"
     cargo fmt --all
   )
+
+  echo "Running clippy (auto-fix when possible)"
+  (
+    cd "$ROOT_DIR"
+    cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged -- -D warnings
+  )
 else
   echo "Running rustfmt check"
   (
     cd "$ROOT_DIR"
     cargo fmt --all -- --check
   )
-fi
 
-echo "Running clippy"
-(
-  cd "$ROOT_DIR"
-  cargo clippy --all-targets --all-features -- -D warnings
-)
+  echo "Running clippy"
+  (
+    cd "$ROOT_DIR"
+    cargo clippy --all-targets --all-features -- -D warnings
+  )
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SCRIPT: lint.sh
+# DESCRIPTION: Run Rust formatting and clippy lint checks.
+# USAGE: ./lint
+# PARAMETERS:
+#  -h           : Show help message and exit.
+#  -f           : Fix formatting with rustfmt before linting.
+# EXAMPLE: ./lint
+# ----------------------------------------------------
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ "$(basename "$SCRIPT_DIR")" = "scripts" ]; then
+  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/script-helpers}"
+else
+  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/scripts/script-helpers}"
+fi
+source "$SCRIPT_HELPERS_DIR/helpers.sh"
+shlib_import help logging
+parse_common_args "$@"
+
+fix_mode=0
+while getopts "hf?" opt; do
+  case $opt in
+    h)
+      show_help_and_exit "$0" "Run rustfmt and clippy checks." ""
+      ;;
+    f)
+      fix_mode=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ "$fix_mode" -eq 1 ]; then
+  echo "Running rustfmt"
+  (
+    cd "$ROOT_DIR"
+    cargo fmt --all
+  )
+else
+  echo "Running rustfmt check"
+  (
+    cd "$ROOT_DIR"
+    cargo fmt --all -- --check
+  )
+fi
+
+echo "Running clippy"
+(
+  cd "$ROOT_DIR"
+  cargo clippy --all-targets --all-features -- -D warnings
+)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,7 +2,9 @@
 # SCRIPT: run.sh
 # DESCRIPTION: Build the release binary and run it against a local test image.
 # USAGE: ./run
-# PARAMETERS: None
+# PARAMETERS:
+#  -h           : Show help message and exit.
+#  [-g [<dir>]] : Gallery | Gallery with directory
 # EXAMPLE: ./run
 # ----------------------------------------------------
 
@@ -16,6 +18,36 @@ source "$SCRIPT_HELPERS_DIR/helpers.sh"
 shlib_import help logging
 parse_common_args "$@"
 
+# Process optarg parameters passed to the script.
+gallery_mode=0
+additional_param=""
+
+while getopts "h?g" opt; do
+  case $opt in
+    h)
+      show_help_and_exit "$0" "Run the release binary against a test image." ""
+      additional_param="-h"
+      ;;
+    g)
+      gallery_mode=1
+      additional_param="-g"
+      # Check if there's a non-option argument that could be the directory
+      shift $((OPTIND - 1))
+      if [ $# -gt 0 ] && [[ "$1" != -* ]]; then
+        gallery_dir="$1"
+        additional_param="$additional_param \"${gallery_dir}\""
+        shift
+      else
+        gallery_dir=""
+      fi
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2 
+      exit 1
+      ;;
+  esac
+done
+
 test_image="test.jpeg"
 
 cargo build --release
@@ -25,7 +57,19 @@ if [ $? -ne 0 ]; then
 fi
 
 # run the cargo build command
-cargo run --release ./src/${test_image}
+# If in gallery mode, pass the gallery flag and optional directory
+if [[ $gallery_mode == 1 ]]; then
+  echo "Running in gallery mode"
+  if [ -n "$gallery_dir" ]; then
+    cargo run --release -- -g "$gallery_dir"
+  else
+    cargo run --release -- -g
+  fi
+else
+  echo "Running in single image mode"
+  cargo run --release -- "./src/${test_image}"
+fi
+
 if [ $? -ne 0 ]; then
     echo "Cargo run failed"
     exit 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,15 @@
 //! - Dragana (as per file path)
 //!
 use colored::*;
+use crossterm::cursor;
+use crossterm::event::{self, Event, KeyCode};
+use crossterm::terminal::{self, ClearType};
+use crossterm::ExecutableCommand;
 use image::{GenericImageView, Pixel};
 use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use terminal_size::terminal_size;
 
 // Struct to determine console dimensions and resize the image accordingly.
@@ -113,21 +120,43 @@ impl ImageRenderer {
     }
 }
 
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn new() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
 // Print help information
 fn print_help(program_name: &str) {
     println!(
-        "Usage: {} <image-path> [options]\n\
+        "Usage:\n\
+         \t{0} <image-path> [options]\n\
+         \t{0} -g [path]\n\
+         \n\
          Options:\n\
-         \t-w <width>\tSet max width\n\
-         \t-h <height>\tSet max height\n\
-         \t--help\t\tShow this help message\n\
+         \t-w <width>     Set max width\n\
+         \t-h <height>    Set max height\n\
+         \t-g [path]      Gallery mode (left/right to navigate, q to quit, c to copy path)\n\
+         \t--help         Show this help message\n\
          \n\
          Environment variables:\n\
-         \tCOLUMNS\t\tOverride detected terminal width\n\
+         \tCOLUMNS        Override detected terminal width\n\
+         \tLINES          Override detected terminal height\n\
          \n\
-         Example:\n\
-         \t{} ./my_image.png -w 100 -h 40",
-        program_name, program_name
+         Examples:\n\
+         \t{0} ./my_image.png -w 100 -h 40\n\
+         \t{0} -g\n\
+         \t{0} -g ./images",
+        program_name
     );
 }
 
@@ -138,6 +167,150 @@ fn parse_arg(args: &[String], flag: &str) -> Option<u32> {
         .and_then(|i| args.get(i + 1).and_then(|v| v.parse::<u32>().ok()))
 }
 
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|a| a == flag)
+}
+
+fn parse_gallery_path(args: &[String]) -> Option<String> {
+    let pos = args.iter().position(|a| a == "-g")?;
+    if let Some(next) = args.get(pos + 1) {
+        if !next.starts_with('-') {
+            return Some(next.clone());
+        }
+    }
+    if let Some(first) = args.get(1) {
+        if !first.starts_with('-') && first != "-g" {
+            return Some(first.clone());
+        }
+    }
+    None
+}
+
+fn is_image_file(path: &Path) -> bool {
+    let ext = match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => ext.to_ascii_lowercase(),
+        None => return false,
+    };
+    matches!(
+        ext.as_str(),
+        "png"
+            | "jpg"
+            | "jpeg"
+            | "gif"
+            | "bmp"
+            | "tiff"
+            | "tif"
+            | "webp"
+            | "tga"
+            | "ico"
+            | "avif"
+    )
+}
+
+fn list_images(dir: &Path) -> io::Result<Vec<PathBuf>> {
+    let mut images = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() && is_image_file(&path) {
+            images.push(path);
+        }
+    }
+    images.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+    Ok(images)
+}
+
+fn render_gallery_image(
+    image_path: &Path,
+    max_width: u32,
+    max_height: u32,
+    footer_row: u16,
+    status: &str,
+) -> io::Result<()> {
+    let mut stdout = io::stdout();
+    stdout.execute(terminal::Clear(ClearType::All))?;
+    stdout.execute(cursor::MoveTo(0, 0))?;
+
+    let renderer = ImageRenderer::new(&image_path.to_string_lossy());
+    renderer.render(max_width, max_height);
+
+    stdout.execute(cursor::MoveTo(0, footer_row))?;
+    let full_path = fs::canonicalize(image_path).unwrap_or_else(|_| image_path.to_path_buf());
+    if status.is_empty() {
+        println!("Path: {}", full_path.display());
+    } else {
+        println!("Path: {} | {}", full_path.display(), status);
+    }
+    stdout.flush()?;
+    Ok(())
+}
+
+fn copy_to_clipboard(text: &str) -> Result<(), String> {
+    match arboard::Clipboard::new() {
+        Ok(mut clipboard) => clipboard.set_text(text.to_string()).map_err(|e| e.to_string()),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+fn run_gallery(
+    input_path: &Path,
+    max_width: u32,
+    max_height: u32,
+    footer_row: u16,
+) -> Result<(), String> {
+    let dir = if input_path.is_dir() {
+        input_path
+    } else {
+        input_path.parent().unwrap_or(input_path)
+    };
+    let images = list_images(dir).map_err(|e| e.to_string())?;
+    if images.is_empty() {
+        return Err(format!("No supported images found in {}", dir.display()));
+    }
+
+    let mut index = 0;
+    if input_path.is_file() {
+        if let Some(found) = images.iter().position(|p| p == input_path) {
+            index = found;
+        }
+    }
+
+    let _raw = RawModeGuard::new().map_err(|e| e.to_string())?;
+    let mut status = String::new();
+    loop {
+        render_gallery_image(&images[index], max_width, max_height, footer_row, &status)
+            .map_err(|e| e.to_string())?;
+        status.clear();
+
+        match event::read().map_err(|e| e.to_string())? {
+            Event::Key(key_event) => match key_event.code {
+                KeyCode::Char('q') => break,
+                KeyCode::Char('c') => {
+                    let full_path =
+                        fs::canonicalize(&images[index]).unwrap_or_else(|_| images[index].clone());
+                    match copy_to_clipboard(&full_path.to_string_lossy()) {
+                        Ok(()) => status = "copied".to_string(),
+                        Err(err) => status = format!("copy failed: {}", err),
+                    }
+                }
+                KeyCode::Left => {
+                    if index == 0 {
+                        index = images.len() - 1;
+                    } else {
+                        index -= 1;
+                    }
+                }
+                KeyCode::Right => {
+                    index = (index + 1) % images.len();
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 // Main function
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -145,14 +318,14 @@ fn main() {
         print_help(&args[0]);
         std::process::exit(0);
     }
-    if args.len() < 2 {
+    let gallery_mode = has_flag(&args, "-g");
+    if !gallery_mode && args.len() < 2 {
         eprintln!(
             "Usage: {} <image-path> [options]\nTry --help for more information.",
             args[0]
         );
         std::process::exit(1);
     }
-    let image_path = &args[1];
 
     // Parse optional width and height
     let max_width = parse_arg(&args, "-w");
@@ -180,6 +353,19 @@ fn main() {
     let final_width = max_width.unwrap_or(env_width);
     let final_height = max_height.unwrap_or(env_height);
 
-    let renderer = ImageRenderer::new(image_path);
-    renderer.render(final_width, final_height);
+    if gallery_mode {
+        let gallery_path = parse_gallery_path(&args).unwrap_or_else(|| ".".to_string());
+        let footer_row = env_height.saturating_sub(1) as u16;
+        let image_height = final_height.saturating_sub(1).max(1);
+        if let Err(err) =
+            run_gallery(Path::new(&gallery_path), final_width, image_height, footer_row)
+        {
+            eprintln!("Gallery mode error: {}", err);
+            std::process::exit(1);
+        }
+    } else {
+        let image_path = &args[1];
+        let renderer = ImageRenderer::new(image_path);
+        renderer.render(final_width, final_height);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,10 +284,8 @@ fn wrap_footer(text: &str, columns: u32) -> Vec<String> {
 }
 
 fn copy_to_clipboard(text: &str, owner: &mut Option<Child>) -> Result<(), String> {
-    if is_x11_session() {
-        if copy_with_xclip_owner(text, owner).is_ok() {
-            return Ok(());
-        }
+    if is_x11_session() && copy_with_xclip_owner(text, owner).is_ok() {
+        return Ok(());
     }
     if let Ok(mut clipboard) = arboard::Clipboard::new() {
         if clipboard.set_text(text.to_string()).is_ok() {
@@ -428,8 +426,8 @@ fn run_gallery(input_path: &Path, max_width: u32, max_height: u32) -> Result<(),
             .map_err(|e| e.to_string())?;
         status = None;
 
-        match event::read().map_err(|e| e.to_string())? {
-            Event::Key(key_event) => match key_event.code {
+        if let Event::Key(key_event) = event::read().map_err(|e| e.to_string())? {
+            match key_event.code {
                 KeyCode::Char('q') => break,
                 KeyCode::Char('c') if is_copy_shortcut(&key_event) => {
                     let full_path =
@@ -450,8 +448,7 @@ fn run_gallery(input_path: &Path, max_width: u32, max_height: u32) -> Result<(),
                     index = (index + 1) % images.len();
                 }
                 _ => {}
-            },
-            _ => {}
+            }
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,11 @@ fn print_help(program_name: &str) {
          \t-g [path]      Gallery mode (left/right to navigate, q to quit, {1} to copy)\n\
          \t--help         Show this help message\n\
          \n\
+         Gallery mode controls:\n\
+         \tLeft/Right     Previous/next image\n\
+         \t{1}            Copy full path of current image\n\
+         \tq              Quit gallery\n\
+         \n\
          Environment variables:\n\
          \tCOLUMNS        Override detected terminal width\n\
          \tLINES          Override detected terminal height\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,13 @@
 //! ## Author
 //! - Dragana (as per file path)
 //!
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use colored::*;
+use crossterm::ExecutableCommand;
 use crossterm::cursor;
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use base64::Engine;
 use crossterm::terminal::{self, ClearType};
-use crossterm::ExecutableCommand;
 use image::{GenericImageView, Pixel};
 use std::env;
 use std::fs;
@@ -171,8 +171,7 @@ fn print_help(program_name: &str) {
          \t{0} ./my_image.png -w 100 -h 40\n\
          \t{0} -g\n\
          \t{0} -g ./images",
-        program_name,
-        copy_hint
+        program_name, copy_hint
     );
 }
 
@@ -209,17 +208,7 @@ fn is_image_file(path: &Path) -> bool {
     };
     matches!(
         ext.as_str(),
-        "png"
-            | "jpg"
-            | "jpeg"
-            | "gif"
-            | "bmp"
-            | "tiff"
-            | "tif"
-            | "webp"
-            | "tga"
-            | "ico"
-            | "avif"
+        "png" | "jpg" | "jpeg" | "gif" | "bmp" | "tiff" | "tif" | "webp" | "tga" | "ico" | "avif"
     )
 }
 
@@ -294,7 +283,6 @@ fn wrap_footer(text: &str, columns: u32) -> Vec<String> {
     lines
 }
 
-
 fn copy_to_clipboard(text: &str, owner: &mut Option<Child>) -> Result<(), String> {
     if is_x11_session() {
         if copy_with_xclip_owner(text, owner).is_ok() {
@@ -339,7 +327,9 @@ fn copy_with_xclip_owner(text: &str, owner: &mut Option<Child>) -> Result<(), St
         .spawn()
         .map_err(|e| e.to_string())?;
     if let Some(stdin) = child.stdin.as_mut() {
-        stdin.write_all(text.as_bytes()).map_err(|e| e.to_string())?;
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| e.to_string())?;
     }
     let _ = child.stdin.take();
     cleanup_clipboard_owner(owner);
@@ -379,7 +369,9 @@ fn try_copy_with_command(cmd: &str, args: &[&str], text: &str) -> Result<(), Str
         .spawn()
         .map_err(|e| e.to_string())?;
     if let Some(stdin) = child.stdin.as_mut() {
-        stdin.write_all(text.as_bytes()).map_err(|e| e.to_string())?;
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| e.to_string())?;
     }
     let status = child.wait().map_err(|e| e.to_string())?;
     if status.success() {
@@ -409,11 +401,7 @@ fn is_wsl() -> bool {
     false
 }
 
-fn run_gallery(
-    input_path: &Path,
-    max_width: u32,
-    max_height: u32,
-) -> Result<(), String> {
+fn run_gallery(input_path: &Path, max_width: u32, max_height: u32) -> Result<(), String> {
     let dir = if input_path.is_dir() {
         input_path
     } else {
@@ -521,9 +509,7 @@ fn main() {
 
     if gallery_mode {
         let gallery_path = parse_gallery_path(&args).unwrap_or_else(|| ".".to_string());
-        if let Err(err) =
-            run_gallery(Path::new(&gallery_path), final_width, final_height)
-        {
+        if let Err(err) = run_gallery(Path::new(&gallery_path), final_width, final_height) {
             eprintln!("Gallery mode error: {}", err);
             std::process::exit(1);
         }


### PR DESCRIPTION
This pull request introduces a major new gallery mode feature, improves clipboard integration across platforms, and updates documentation and helper scripts to reflect these enhancements. The gallery mode allows users to browse images in a directory with keyboard navigation and copy image paths to the clipboard, with robust cross-platform support. Additionally, the README and project documentation have been updated for clarity, and the build script and dependencies now support the new features.

**Major feature: Gallery mode and improved clipboard handling**

- **Gallery Mode Implementation:**
  - Added a new gallery mode (`-g` flag) that lets users browse images in a directory using left/right arrows, view the full image path, and copy the current image path to the clipboard. The gallery dynamically adjusts image and footer height to fit the terminal and handles navigation and clipboard shortcuts for both macOS and other platforms. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR47-R58) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR186-L155) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR522-R535)
  - Updated the CLI help and usage instructions to describe gallery mode controls and options. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR115-R175) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R76)

- **Cross-platform Clipboard Support:**
  - Implemented robust clipboard copying for gallery mode, supporting X11 (with owner retention), Wayland, WSL, macOS, and fallback to OSC 52 escape sequences.
  - Added new dependencies: `crossterm` for terminal/key handling, `arboard` for clipboard, and `base64` for OSC 52 support.

**Documentation and helper updates**

- **Documentation Improvements:**
  - Updated `README.md` to reflect gallery mode, new usage patterns, and clarified the rendering method (now using colored background blocks instead of terminal graphics protocols). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R76)
  - Added `AGENTS.md` with detailed repository, coding, testing, and PR guidelines.

- **Build and Script Enhancements:**
  - Enhanced `scripts/run.sh` to support the new gallery mode and help options, including argument parsing and mode selection. [[1]](diffhunk://#diff-bb563bfe483a3a9b1649cf50d2246475b9565947f5226b94fa0d72c9786ab298L5-R7) [[2]](diffhunk://#diff-bb563bfe483a3a9b1649cf50d2246475b9565947f5226b94fa0d72c9786ab298R21-R50) [[3]](diffhunk://#diff-bb563bfe483a3a9b1649cf50d2246475b9565947f5226b94fa0d72c9786ab298L28-R72)

**Changelog**

- Added entries describing the gallery rendering alignment, full path display, and improved clipboard handling.