### PR TITLE
fix: correct linting; update documentation abot it

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+./scripts/lint.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project are documented in this file.
 This format is based on Keep a Changelog and follows Semantic Versioning.
 
+## [0.5.1] - 2026-01-04
+### Changed
+- Apply smoother resampling when rendering images (both upscaling and downscaling) for cleaner CLI output.
+- Enforce local linting via `./run` and a git pre-commit hook configured during setup.
+
 ## [0.5.0] - 2025-09-18
 ### Changed
 - Fix gallery rendering alignment by using explicit CRLF line endings in raw mode.
@@ -31,7 +36,8 @@ This format is based on Keep a Changelog and follows Semantic Versioning.
 - Add Release info after tagging and release GH Action completes building artifacts
 - Add links to built artifacts in the Release information after the process completes.
 
-[Unreleased]: https://github.com/nikolareljin/image-view/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/nikolareljin/image-view/compare/0.5.1...HEAD
+[0.5.1]: https://github.com/nikolareljin/image-view/releases/tag/0.5.1
 [0.5.0]: https://github.com/nikolareljin/image-view/releases/tag/0.5.0
 [0.2.0]: https://github.com/nikolareljin/image-view/releases/tag/0.2.0
 [0.1.0-RC]: https://github.com/nikolareljin/image-view/releases/tag/0.1.0-RC

--- a/README.md
+++ b/README.md
@@ -71,6 +71,36 @@ This installs `image-view` into `~/.cargo/bin`. Ensure it is on your `PATH`.
 
 - edit `./src/main.rs`
 - build: `cargo run ./src/test.jpeg`
+- local run (with lint checks): `./run`
+
+## Scripts
+
+Run from repo root unless noted.
+
+`./run`
+- `-h`: show help
+- `-g [<dir>]`: gallery mode (optional directory)
+
+`./scripts/lint.sh`
+- `-h`: show help
+- `-f`: auto-fix formatting and clippy where possible, then re-check
+
+`./scripts/build.sh`
+- No flags
+
+`./scripts/test.sh`
+- No flags
+
+`./setup`
+- No flags (uses env vars `INSTALL_DIR`, `PROFILE_FILE`)
+
+`./update`
+- No flags
+
+## Local Development
+
+- `./run` runs linting (`cargo fmt --check` and `cargo clippy -D warnings`) before building and running.
+- `./setup` configures a pre-commit hook to run `./scripts/lint.sh`.
 
 ## Usage
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,13 +7,11 @@
 # ----------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$(basename "$SCRIPT_DIR")" = "scripts" ]; then
-  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/script-helpers}"
+  ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 else
-  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/scripts/script-helpers}"
+  ROOT_DIR="$SCRIPT_DIR"
 fi
-source "$SCRIPT_HELPERS_DIR/helpers.sh"
-shlib_import help logging
-parse_common_args "$@"
+source "$ROOT_DIR/scripts/include.sh" "$@"
 
 BUILD_MACOS="${BUILD_MACOS:-0}"
 RUN_LINT="${RUN_LINT:-1}"

--- a/scripts/include.sh
+++ b/scripts/include.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SCRIPT: include.sh
+# DESCRIPTION: Common loader for repo scripts (helpers + standard args).
+# USAGE: source ./scripts/include.sh "$@"
+# ----------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$ROOT_DIR/scripts/script-helpers}"
+
+if [ ! -f "$SCRIPT_HELPERS_DIR/helpers.sh" ]; then
+  echo "script-helpers is missing. Run ./update to initialize submodules." >&2
+  exit 1
+fi
+
+source "$SCRIPT_HELPERS_DIR/helpers.sh"
+shlib_import help logging
+parse_common_args "$@"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -11,13 +11,27 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$(basename "$SCRIPT_DIR")" = "scripts" ]; then
-  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/script-helpers}"
+  ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 else
-  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/scripts/script-helpers}"
+  ROOT_DIR="$SCRIPT_DIR"
 fi
-source "$SCRIPT_HELPERS_DIR/helpers.sh"
-shlib_import help logging
-parse_common_args "$@"
+SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$ROOT_DIR/scripts/script-helpers}"
+if [ -f "$SCRIPT_HELPERS_DIR/helpers.sh" ]; then
+  source "$SCRIPT_HELPERS_DIR/helpers.sh"
+  shlib_import help logging
+  parse_common_args "$@"
+else
+  show_help_and_exit() {
+    echo "Usage: $1"
+    echo
+    echo "$2"
+    if [ -n "$3" ]; then
+      echo
+      echo "$3"
+    fi
+    exit 0
+  }
+fi
 
 fix_mode=0
 while getopts "hf?" opt; do
@@ -35,7 +49,6 @@ while getopts "hf?" opt; do
   esac
 done
 
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 export CARGO_INCREMENTAL=0
 export CARGO_TERM_COLOR=always
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT_DIR/target}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -14,23 +14,7 @@ if [ "$(basename "$SCRIPT_DIR")" = "scripts" ]; then
 else
   ROOT_DIR="$SCRIPT_DIR"
 fi
-SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$ROOT_DIR/scripts/script-helpers}"
-if [ -f "$SCRIPT_HELPERS_DIR/helpers.sh" ]; then
-  source "$SCRIPT_HELPERS_DIR/helpers.sh"
-  shlib_import help logging
-  parse_common_args "$@"
-else
-  show_help_and_exit() {
-    echo "Usage: $1"
-    echo
-    echo "$2"
-    if [ -n "$3" ]; then
-      echo
-      echo "$3"
-    fi
-    exit 0
-  }
-fi
+source "$ROOT_DIR/scripts/include.sh" "$@"
 
 # Process optarg parameters passed to the script.
 gallery_mode=0

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -74,6 +74,14 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Reformat with cargo fmt --
+cargo fmt --
+if [ $? -ne 0 ]; then
+    echo "Linting failed"
+    exit 1
+fi
+
+# Cargo build
 cargo build --release
 if [ $? -ne 0 ]; then
     echo "Cargo build failed"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,10 +18,7 @@ if [ "$(basename "$SCRIPT_DIR")" = "scripts" ]; then
 else
   ROOT_DIR="$SCRIPT_DIR"
 fi
-SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$ROOT_DIR/scripts/script-helpers}"
-source "$SCRIPT_HELPERS_DIR/helpers.sh"
-shlib_import help logging
-parse_common_args "$@"
+source "$ROOT_DIR/scripts/include.sh" "$@"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 PROFILE_FILE="${PROFILE_FILE:-$HOME/.profile}"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -30,6 +30,12 @@ if ! command -v cargo >/dev/null 2>&1; then
   exit 1
 fi
 
+if command -v git >/dev/null 2>&1; then
+  if git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$ROOT_DIR" config core.hooksPath .githooks
+  fi
+fi
+
 mkdir -p "$INSTALL_DIR"
 
 cargo build --release --manifest-path "$ROOT_DIR/Cargo.toml"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,13 +9,11 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ "$(basename "$SCRIPT_DIR")" = "scripts" ]; then
-  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/script-helpers}"
+  ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 else
-  SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$SCRIPT_DIR/scripts/script-helpers}"
+  ROOT_DIR="$SCRIPT_DIR"
 fi
-source "$SCRIPT_HELPERS_DIR/helpers.sh"
-shlib_import help logging
-parse_common_args "$@"
+source "$ROOT_DIR/scripts/include.sh" "$@"
 
 # Install dependencies (uncomment if needed)
 sudo apt-get update && sudo apt-get install -y \

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -17,9 +17,18 @@ else
   ROOT_DIR="$SCRIPT_DIR"
 fi
 SCRIPT_HELPERS_DIR="${SCRIPT_HELPERS_DIR:-$ROOT_DIR/scripts/script-helpers}"
-source "$SCRIPT_HELPERS_DIR/helpers.sh"
-shlib_import help logging
-parse_common_args "$@"
+if [ -f "$SCRIPT_HELPERS_DIR/helpers.sh" ]; then
+  source "$SCRIPT_HELPERS_DIR/helpers.sh"
+  shlib_import help logging
+  parse_common_args "$@"
+else
+  if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    echo "Usage: $0"
+    echo
+    echo "Sync and update git submodules, even if the repo was cloned without them."
+    exit 0
+  fi
+fi
 
 if ! command -v git >/dev/null 2>&1; then
   echo "Git is required to update submodules." >&2

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ impl ImageRenderer {
 
         // Scale so that the image fits within both max_width and max_height constraints.
         // Choose the smaller scale factor to ensure both dimensions fit.
-        let scale = scale_h.min(scale_w).min(1.0); // Don't upscale
+        let scale = scale_h.min(scale_w);
 
         // Ensure new_width is at least 1 to avoid zero-width images
         let new_width = ((img_width as f32 * scale).round() as u32).max(1);
@@ -118,7 +118,7 @@ impl ImageRenderer {
 
         let resized_img =
             self.image
-                .resize(new_width, new_height, image::imageops::FilterType::Nearest);
+                .resize(new_width, new_height, image::imageops::FilterType::CatmullRom);
 
         let stdout = io::stdout();
         let mut stdout = stdout.lock();

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,9 +116,11 @@ impl ImageRenderer {
         let new_width = ((img_width as f32 * scale).round() as u32).max(1);
         let new_height = ((img_height as f32 * scale).round() as u32).max(1);
 
-        let resized_img =
-            self.image
-                .resize(new_width, new_height, image::imageops::FilterType::CatmullRom);
+        let resized_img = self.image.resize(
+            new_width,
+            new_height,
+            image::imageops::FilterType::CatmullRom,
+        );
 
         let stdout = io::stdout();
         let mut stdout = stdout.lock();


### PR DESCRIPTION
This pull request introduces improvements to both the development workflow and image rendering quality. The most significant changes are the enforcement of local linting before code runs or commits, the addition of a pre-commit git hook, and the switch to smoother image resampling for better CLI output. Documentation has also been updated to reflect these enhancements.

**Development workflow improvements:**

* Added a git pre-commit hook (`.githooks/pre-commit`) that runs `./scripts/lint.sh` to enforce linting before commits. The hook is automatically configured during setup. 
* Updated `scripts/run.sh` so that running `./run` performs lint checks before building and running the code. If linting fails, the process aborts. 
* Improved script helper logic in `scripts/lint.sh` and `scripts/run.sh` for robustness and better help messaging. 

**Image rendering enhancement:**

* Changed image resampling filter from `Nearest` to `CatmullRom` in `src/main.rs` for both upscaling and downscaling, resulting in smoother and cleaner CLI image output.

**Documentation updates:**

* Updated `README.md` and `CHANGELOG.md` to document new linting requirements, the pre-commit hook, and improved image rendering. 