### PR TITLE
ci: add automated release dispatch on release/* merges

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -7,7 +7,10 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  actions: write
 
 jobs:
   tag:
     uses: nikolareljin/ci-helpers/.github/workflows/auto-tag-release.yml@production
+    with:
+      release_workflow: release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@ on:
       - '*.*.*-rc*'
       - 'v*.*.*-RC*'
       - '*.*.*-RC*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag to build and release (e.g. 0.7.1)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,3 +24,4 @@ jobs:
     uses: nikolareljin/ci-helpers/.github/workflows/rust-release.yml@production
     with:
       bin_name: "image-view"
+      release_tag: ${{ github.event.inputs.release_tag || github.ref_name }}


### PR DESCRIPTION
## Summary

- `auto-tag-release.yml`: adds `release_workflow: release.yml` and `actions: write` permission so the tagger dispatches the release workflow after pushing the version tag
- `release.yml`: adds `workflow_dispatch` trigger with `release_tag` input (required by the dispatch mechanism); passes `release_tag` through to `rust-release.yml@production`

## Why

GITHUB_TOKEN-created tags do not trigger `push` tag events in other workflows (GitHub security restriction). Without the `release_workflow` dispatch, releases have to be triggered manually after every tag. This change makes the full flow automatic:

```
release/x.y.z → main merge → auto-tag creates tag → dispatches release.yml → rust-release builds + publishes
```

## Test plan

- [ ] Merge a `release/x.y.z` PR and verify `auto-tag-release.yml` creates the tag, then dispatches `release.yml` automatically
- [ ] Verify the GitHub Release is created with all expected binary artifacts
- [ ] Optionally run `gh workflow run release.yml --field release_tag=<tag>` to backfill an existing tag