### PR TITLE
Superseded: Add clone traffic chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,11 @@ Contributions are welcome! Please open an issue or submit a pull request for any
 
 ## License
 This project is licensed under the MIT License. See the LICENSE file for more details.
+
+---
+
+## Clone traffic
+
+![Clone traffic](https://raw.githubusercontent.com/nikolareljin/stats/main/charts/image-view.svg)
+
+_Updated daily. Total and unique cloners over the last 14 days._


### PR DESCRIPTION
## Summary

- Add the clone traffic SVG chart from nikolareljin/stats to the README.

## Validation

- Verified the stats SVG exists at charts/image-view.svg before updating the README.
- Ran git diff --check for the README change.